### PR TITLE
Fixed compile-time warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! A library for reading and writing Android smali files
 //!
-use std::collections::HashSet;
 use std::path::PathBuf;
 use crate::types::{SmaliClass, SmaliError};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ pub fn find_smali_files(dir: &PathBuf) -> Result<Vec<SmaliClass>, SmaliError>
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::path::Path;
     use crate::types::{MethodSignature, ObjectIdentifier, SmaliClass, TypeSignature};
 

--- a/src/smali_parse.rs
+++ b/src/smali_parse.rs
@@ -4,7 +4,7 @@ use nom::branch::{ alt };
 use nom::character::complete::{alphanumeric1, char, multispace0, multispace1, newline, none_of, not_line_ending, one_of};
 use nom::combinator::value;
 use nom::Err::Failure;
-use nom::error::{Error, ErrorKind, ParseError};
+use nom::error::{Error, ErrorKind};
 use nom::{Err, IResult};
 use nom::multi::{many0};
 use nom::sequence::{delimited, pair};
@@ -100,7 +100,7 @@ fn parse_typesignature(smali: &str) -> IResult<&str, TypeSignature>
     }
     // Array
     let b:IResult<&str, &str> = tag("[")(smali);
-    if let IResult::Ok((o, t)) = b
+    if let IResult::Ok((o, _)) = b
     {
         let (o, t) = parse_typesignature(o)?;
         return IResult::Ok((o, TypeSignature::Array(Box::new(t))))

--- a/src/smali_parse.rs
+++ b/src/smali_parse.rs
@@ -1,7 +1,7 @@
 
 use nom::bytes::complete::{escaped, is_not, tag, take_while};
 use nom::branch::{ alt };
-use nom::character::complete::{alphanumeric1, char, multispace0, multispace1, newline, none_of, not_line_ending, one_of};
+use nom::character::complete::{alphanumeric1, char, multispace0, multispace1, space0, newline, none_of, not_line_ending, one_of};
 use nom::combinator::value;
 use nom::Err::Failure;
 use nom::error::{Error, ErrorKind};
@@ -398,7 +398,7 @@ fn parse_method(smali: &str) -> IResult<&str, SmaliMethod>
     let (o, name) = take_while(|c| c != '(')(input)?;
     let (o, ms) = parse_methodsignature(o)?;
 
-    let (o, type_sig) = take_until_eol(o)?;
+    let (o, _) = pair(space0, newline)(o)?;
 
     // locals
     let l = ws(tag(".locals"))(o);

--- a/src/types.rs
+++ b/src/types.rs
@@ -507,7 +507,7 @@ impl SmaliClass {
 
         // Create package dir structure
         let class_name = self.name.as_java_type();
-        let mut package_dirs: Vec<&str> = class_name.split('.').collect();
+        let package_dirs: Vec<&str> = class_name.split('.').collect();
         let mut dir = PathBuf::from(path);
         for p in package_dirs[0..package_dirs.len()-1].to_vec()
         {


### PR DESCRIPTION
There is one compile-time warning left:

```
warning: unused variable: `type_sig`
   --> smali/src/smali_parse.rs:402:13
402 |     let (o, type_sig) = take_until_eol(o)?;
    |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_type_sig`
    |
    = note: `#[warn(unused_variables)]` on by default
```

From the look of it, this one is an actual bug: return value of a method isn’t stored. Consequently, all methods are rendered with `void` return type when saving.