### PR TITLE
Parse interface declarations correctly

### DIFF
--- a/src/smali_parse.rs
+++ b/src/smali_parse.rs
@@ -58,6 +58,7 @@ fn parse_modifiers(smali: &str) -> IResult<&str, Vec<Modifier>>
                                               ws(tag("static ")),
                                               ws(tag("final ")),
                                               ws(tag("abstract ")),
+                                              ws(tag("interface ")),
                                               ws(tag("synthetic ")),
                                               ws(tag("transient ")),
                                               ws(tag("volatile ")),
@@ -580,7 +581,7 @@ pub(crate) fn parse_class(smali: &str) -> IResult<&str, SmaliClass>
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use crate::smali_parse::{quoted, parse_annotation_element, parse_class, parse_class_line, parse_enum, parse_field, parse_implements_line, parse_java_array, parse_super_line, take_until_eol, parse_typesignature, parse_methodsignature};
+    use super::*;
     use crate::types::{AnnotationValue};
 
     #[test]
@@ -623,8 +624,9 @@ mod tests {
 
     #[test]
     fn test_parse_class_line() {
-        let (_, l) = parse_class_line(".class public final Lokhttp3/OkHttpClient;\n").unwrap();
-        println!("{:?}", l);
+        let (_, (modifiers, type_name)) = parse_class_line(".class public final interface Lokhttp3/OkHttpClient;\n").unwrap();
+        assert_eq!(modifiers, [Modifier::Public, Modifier::Final, Modifier::Interface]);
+        assert_eq!(type_name, "Lokhttp3/OkHttpClient;");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -160,7 +160,7 @@ impl TypeSignature {
 /// Simple enum to represent Java method, field and class modifiers
 ///
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Modifier {
     Public,
     Protected,
@@ -168,6 +168,7 @@ pub enum Modifier {
     Static,
     Final,
     Abstract,
+    Interface,
     Synthetic,
     Transient,
     Volatile,
@@ -177,40 +178,42 @@ pub enum Modifier {
 }
 
 impl Modifier {
-    pub fn from_str(s: &str) -> Modifier
+    pub fn from_str(s: &str) -> Self
     {
         match s {
-            "public" => Modifier::Public,
-            "protected" => Modifier::Protected,
-            "private" => Modifier::Private,
-            "static" => Modifier::Static,
-            "final" => Modifier::Final,
-            "abstract" => Modifier::Abstract,
-            "synthetic" => Modifier::Synthetic,
-            "transient" => Modifier::Transient,
-            "volatile" => Modifier::Volatile,
-            "synchronized" => Modifier::Synchronized,
-            "native" => Modifier::Native,
-            "varargs" => Modifier::Varargs,
-            _ => Modifier::Public
+            "public" => Self::Public,
+            "protected" => Self::Protected,
+            "private" => Self::Private,
+            "static" => Self::Static,
+            "final" => Self::Final,
+            "abstract" => Self::Abstract,
+            "interface" => Self::Interface,
+            "synthetic" => Self::Synthetic,
+            "transient" => Self::Transient,
+            "volatile" => Self::Volatile,
+            "synchronized" => Self::Synchronized,
+            "native" => Self::Native,
+            "varargs" => Self::Varargs,
+            _ => Self::Public
         }
     }
 
     pub fn to_str(&self) -> &str
     {
         match self {
-            Modifier::Public => "public",
-            Modifier::Protected => "protected",
-            Modifier::Private => "private",
-            Modifier::Static => "static",
-            Modifier::Final => "final",
-            Modifier::Abstract => "abstract",
-            Modifier::Synthetic => "synthetic",
-            Modifier::Transient => "transient",
-            Modifier::Volatile => "volatile",
-            Modifier::Synchronized => "synchronized",
-            Modifier::Native => "native",
-            Modifier::Varargs => "varargs",
+            Self::Public => "public",
+            Self::Protected => "protected",
+            Self::Private => "private",
+            Self::Static => "static",
+            Self::Final => "final",
+            Self::Abstract => "abstract",
+            Self::Interface => "interface",
+            Self::Synthetic => "synthetic",
+            Self::Transient => "transient",
+            Self::Volatile => "volatile",
+            Self::Synchronized => "synchronized",
+            Self::Native => "native",
+            Self::Varargs => "varargs",
         }
     }
 }


### PR DESCRIPTION
The code currently won’t recognize the `interface` keyword. So interfaces are parsed with a class name like `nterface abstract khttp3.OkHttpClient`.